### PR TITLE
tv: mostra menu antigo se DEBUG=true for passado

### DIFF
--- a/tv.sh
+++ b/tv.sh
@@ -67,44 +67,65 @@ USER_AGENT=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 50)
 # Checks if the media player (mpv) is installed
 type $PLAYER &>/dev/null || { echo "$PLAYER não está instalado"; exit 1; }
 
-# Main loop to display the menu consistently with colors
-while true; do
-  # Clear the screen and display the channel list with colors and aligned numbers
-  clear
-  echo -e "\e[32mCanais disponíveis:\e[0m"
-  for j in "${!TITLES[@]}"; do
-    if [ "$j" -lt 9 ]; then
-      # Add an extra space before single-digit numbers (1-9)
-      echo -e "\e[37m $((j+1)). ${TITLES[j]}\e[0m"
-    else
-      # No extra space for two-digit numbers (10+)
-      echo -e "\e[37m$((j+1)). ${TITLES[j]}\e[0m"
+if [ "$DEBUG" = "true" ]; then
+  PS3="Digite o nº do canal de TV que deseja ver: "
+  select choice in "${TITLES[@]}";
+  do
+    if [[ -n $choice ]]; then
+      for i in ${!TITLES[@]}
+      do
+        if [ "${TITLES[i]}" = "$choice" ]; then
+          # check if dynamic stream
+          if [ "${STREAMS[i]:0:2}" = "__" ]; then
+            $PLAYER --user-agent="$USER_AGENT" $(${STREAMS[i]})
+          else
+            $PLAYER --user-agent="$USER_AGENT" ${STREAMS[i]}
+          fi
+          break
+        fi
+      done
     fi
   done
-  echo
+else
+  # Main loop to display the menu consistently with colors
+  while true; do
+    # Clear the screen and display the channel list with colors and aligned numbers
+    clear
+    echo -e "\e[32mCanais disponíveis:\e[0m"
+    for j in "${!TITLES[@]}"; do
+      if [ "$j" -lt 9 ]; then
+        # Add an extra space before single-digit numbers (1-9)
+        echo -e "\e[37m $((j+1)). ${TITLES[j]}\e[0m"
+      else
+        # No extra space for two-digit numbers (10+)
+        echo -e "\e[37m$((j+1)). ${TITLES[j]}\e[0m"
+      fi
+    done
+    echo
 
-  # Prompt user for input
-  read -p "Digite o nº do canal de TV que deseja ver (ou 'x' para sair): " choice
+    # Prompt user for input
+    read -p "Digite o nº do canal de TV que deseja ver (ou 'x' para sair): " choice
 
-  # Check if user wants to exit
-  if [[ "$choice" == "x" || "$choice" == "X" ]]; then
-    echo -e "\e[33mA sair...\e[0m"  # Yellow for exit message
-    exit 0
-  fi
-
-  # Convert choice to array index (subtract 1 since list starts at 1)
-  index=$((choice - 1))
-
-  # Check if the choice is a valid index
-  if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$index" -ge 0 ] && [ "$index" -lt "${#TITLES[@]}" ]; then
-    # Check if stream is dynamic
-    if [ "${STREAMS[index]:0:2}" = "__" ]; then
-      $PLAYER --user-agent="$USER_AGENT" $(${STREAMS[index]}) > /dev/null 2>&1
-    else
-      $PLAYER --user-agent="$USER_AGENT" ${STREAMS[index]} > /dev/null 2>&1
+    # Check if user wants to exit
+    if [[ "$choice" == "x" || "$choice" == "X" ]]; then
+      echo -e "\e[33mA sair...\e[0m"  # Yellow for exit message
+      exit 0
     fi
-  else
-    echo -e "\e[31mSeleção inválida.\e[0m"  # Red for invalid selection
-    sleep 1  # Pause briefly to let the user see the message
-  fi
-done
+
+    # Convert choice to array index (subtract 1 since list starts at 1)
+    index=$((choice - 1))
+
+    # Check if the choice is a valid index
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$index" -ge 0 ] && [ "$index" -lt "${#TITLES[@]}" ]; then
+      # Check if stream is dynamic
+      if [ "${STREAMS[index]:0:2}" = "__" ]; then
+        $PLAYER --user-agent="$USER_AGENT" $(${STREAMS[index]}) > /dev/null 2>&1
+      else
+        $PLAYER --user-agent="$USER_AGENT" ${STREAMS[index]} > /dev/null 2>&1
+      fi
+    else
+      echo -e "\e[31mSeleção inválida.\e[0m"  # Red for invalid selection
+      sleep 1  # Pause briefly to let the user see the message
+    fi
+  done
+fi


### PR DESCRIPTION
A nova interface é mais bonita, mas não mostra os erros do player, pelo que a interface antiga é útil para debug. Com esta alteração, continuamos a usar a interface nova, mas ainda temos a antiga que usamos se DEBUG=true. Pode ser usado chamando o script com essa variável no ambiente:

$ DEBUG=true ./tv.sh